### PR TITLE
Fixed for Gnome 3.18

### DIFF
--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.14", "3.16"],
+	"shell-version": ["3.14", "3.16", "3.18"],
 	"uuid": "multi-monitors-add-on@spin83",
 	"name": "Multi Monitors Add-On",
 	"settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",


### PR DESCRIPTION
Simple fix, just added it to the metadata. Confirmed to be working on 3.18. 

