### PR TITLE
updated gnome versions metadata to include 3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in dynamic fashion, no restart needed.
 Versions
 ========
 
-* Branch [master](https://github.com/spin83/multi-monitors-add-on/tree/master) contains extension for GNOME 3.14, 3.16 and 3.18
+* Branch [master](https://github.com/spin83/multi-monitors-add-on/tree/master) contains extension for GNOME 3.14, 3.16, 3.18 and 3.20
 * Branch [gnome-3-10](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-10) contains extension for GNOME 3.10
 
 Installation from git

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.14", "3.16", "3.18"],
+	"shell-version": ["3.14", "3.16", "3.18", "3.20"],
 	"uuid": "multi-monitors-add-on@spin83",
 	"name": "Multi Monitors Add-On",
 	"settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",


### PR DESCRIPTION
This patch is an early 3.20 support patch.  It does nothing more than update the metadata (and readme) to indicate that 3.20 is supported.

Test it before merging.