### PR TITLE
fix installation from git command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation from git
 
     git clone git://github.com/spin83/multi-monitors-add-on.git
     cd multi-monitors-add-on
-    cp -r multi-monitors-add-on@spin83 ~/.local/share/gnome-shell/extensions
+    cp -r multi-monitors-add-on@spin83 ~/.local/share/gnome-shell/extensions/multi-monitors-add-on@spin83
 
 Restart the shell and then enable the extension.
 


### PR DESCRIPTION
The `cp` command must includes the folder name in destination path so that the gnome-shell can detect it.