### PR TITLE
Fix schema-id undefined error in 3.30.1

### DIFF
--- a/multi-monitors-add-on@spin83/mmoverview.js
+++ b/multi-monitors-add-on@spin83/mmoverview.js
@@ -171,7 +171,7 @@ const MultiMonitorsThumbnailsBox = new Lang.Class({
 		this._windowDragEndId = Main.overview.connect('window-drag-end', this._onDragEnd.bind(this));
 		this._windowDragCancelledId = Main.overview.connect('window-drag-cancelled', this._onDragCancelled.bind(this));
 		
-		if (this._currentVersion[0]==3 && this._currentVersion[1]<30) {
+		if ('OVERRIDE_SCHEMA' in WorkspaceThumbnail) { // <= 3.30.1
 			this._settings = new Gio.Settings({ schema_id: WorkspaceThumbnail.OVERRIDE_SCHEMA });
 		}
 		else {


### PR DESCRIPTION
The existing if condition tests the minor version number ("30" in 3.30.1), but the gnome-shell change occurred in a patch version number change (3.30.1 had `OVERRIDE_SCHEMA`, 3.30.2 has `MUTTER_SCHEMA`).

Instead of testing version numbers, test for the property directly.