### PR TITLE
Partial support for GNOME 40

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in dynamic fashion, no restart needed.
 Versions
 ========
 
-* Branch [master](https://github.com/realh/multi-monitors-add-on/tree/master) contains extension for GNOME 40
+* Branch [master](https://github.com/realh/multi-monitors-add-on/tree/master) contains extension for GNOME 42
 * Branch [gnome-3-32_3-36](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-32_3-36) contains extension for GNOME 3.32, 3.34 and 3.36
 * Branch [gnome-3-24_3-30](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-24_3-30) contains extension for GNOME 3.24, 3.26, 3.28 and 3.30
 * Branch [gnome-3-20_3-22](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-20_3-22) contains extension for GNOME 3.20 and 3.22

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in dynamic fashion, no restart needed.
 Versions
 ========
 
-* Branch [master](https://github.com/spin83/multi-monitors-add-on/tree/master) contains extension for GNOME 3.38
+* Branch [master](https://github.com/realh/multi-monitors-add-on/tree/master) contains extension for GNOME 40
 * Branch [gnome-3-32_3-36](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-32_3-36) contains extension for GNOME 3.32, 3.34 and 3.36
 * Branch [gnome-3-24_3-30](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-24_3-30) contains extension for GNOME 3.24, 3.26, 3.28 and 3.30
 * Branch [gnome-3-20_3-22](https://github.com/spin83/multi-monitors-add-on/tree/gnome-3-20_3-22) contains extension for GNOME 3.20 and 3.22

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Versions
 Installation from git
 =====================
 
-    git clone git://github.com/spin83/multi-monitors-add-on.git
+    git clone git://github.com/realh/multi-monitors-add-on.git
     cd multi-monitors-add-on
     cp -r multi-monitors-add-on@spin83 ~/.local/share/gnome-shell/extensions/
 

--- a/multi-monitors-add-on@spin83/extension.js
+++ b/multi-monitors-add-on@spin83/extension.js
@@ -65,7 +65,7 @@ class MultiMonitorsAddOn {
 
     constructor() {
         this._settings = Convenience.getSettings();
-        this._ov_settings = new Gio.Settings({ schema: OVERRIDE_SCHEMA });
+//        this._ov_settings = new Gio.Settings({ schema: OVERRIDE_SCHEMA });
         this._mu_settings = new Gio.Settings({ schema: MUTTER_SCHEMA });
 
         this.mmIndicator = null;
@@ -100,8 +100,8 @@ class MultiMonitorsAddOn {
 			return;
 		}
 
-		if(this._ov_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID))
-			this._ov_settings.set_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID, false);
+//		if(this._ov_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID))
+//			this._ov_settings.set_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID, false);
 		if(this._mu_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID))
 			this._mu_settings.set_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID, false);
 
@@ -174,7 +174,10 @@ class MultiMonitorsAddOn {
     }
 
     _switchOffThumbnails() {
-		if (this._ov_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID) || this._mu_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID)) {
+		if (
+//            this._ov_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID) ||
+            this._mu_settings.get_boolean(WORKSPACES_ONLY_ON_PRIMARY_ID))
+        {
 			this._settings.set_string(THUMBNAILS_SLIDER_POSITION_ID, 'none');
 		}
     }
@@ -187,8 +190,8 @@ class MultiMonitorsAddOn {
 		
 		this._mmMonitors = 0;
 
-		this._switchOffThumbnailsOvId = this._ov_settings.connect('changed::'+WORKSPACES_ONLY_ON_PRIMARY_ID,
-																	this._switchOffThumbnails.bind(this));
+//		this._switchOffThumbnailsOvId = this._ov_settings.connect('changed::'+WORKSPACES_ONLY_ON_PRIMARY_ID,
+//																	this._switchOffThumbnails.bind(this));
 		this._switchOffThumbnailsMuId = this._mu_settings.connect('changed::'+WORKSPACES_ONLY_ON_PRIMARY_ID,
 																	this._switchOffThumbnails.bind(this));
 
@@ -206,7 +209,7 @@ class MultiMonitorsAddOn {
 
     disable() {
 		Main.layoutManager.disconnect(this._relayoutId);
-		this._ov_settings.disconnect(this._switchOffThumbnailsOvId);
+//		this._ov_settings.disconnect(this._switchOffThumbnailsOvId);
 		this._mu_settings.disconnect(this._switchOffThumbnailsMuId);
 		
 		this._settings.disconnect(this._showPanelId);

--- a/multi-monitors-add-on@spin83/extension.js
+++ b/multi-monitors-add-on@spin83/extension.js
@@ -40,6 +40,7 @@ const THUMBNAILS_SLIDER_POSITION_ID = 'thumbnails-slider-position';
 
 function copyClass (s, d) {
 //    global.log(s.name +" > "+ d.name);
+    if (!s) throw Error(`copyClass s undefined for d ${d.name}`)
     let propertyNames = Reflect.ownKeys(s.prototype);
     for (let pName of propertyNames.values()) {
 
@@ -114,8 +115,8 @@ class MultiMonitorsAddOn {
 			}
 		}
 
-		this.syncWorkspacesActualGeometry = Main.overview.viewSelector._workspacesDisplay._syncWorkspacesActualGeometry;
-		Main.overview.viewSelector._workspacesDisplay._syncWorkspacesActualGeometry = function() {
+		this.syncWorkspacesActualGeometry = Main.overview.searchController._workspacesDisplay._syncWorkspacesActualGeometry;
+		Main.overview.searchController._workspacesDisplay._syncWorkspacesActualGeometry = function() {
 			if (this._inWindowFade)
 				return;
 
@@ -156,7 +157,7 @@ class MultiMonitorsAddOn {
                 Main.mmOverview[idx].destroy();
         }
         Main.mmOverview = null;
-        Main.overview.viewSelector._workspacesDisplay._syncWorkspacesActualGeometry = this.syncWorkspacesActualGeometry;
+        Main.overview.searchController._workspacesDisplay._syncWorkspacesActualGeometry = this.syncWorkspacesActualGeometry;
     }
 
     _relayout() {

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40", "41"],
+    "shell-version": ["40", "41", "42"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40", "41", "42", "43"],
+    "shell-version": ["40", "41", "42", "43", "44"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["42"],
+    "shell-version": ["40", "42"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40"],
+    "shell-version": ["42"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,10 +1,10 @@
 {
-    "shell-version": ["40", "42"],
+    "shell-version": ["40", "41"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",
     "gettext-domain": "multi-monitors-add-on",
     "description": "Add multiple monitors overview and panel for gnome-shell.",
     "url": "https://github.com/spin83/multi-monitors-add-on.git",
-    "version": 24
+    "version": 25
 }

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -6,5 +6,5 @@
     "gettext-domain": "multi-monitors-add-on",
     "description": "Add multiple monitors overview and panel for gnome-shell.",
     "url": "https://github.com/spin83/multi-monitors-add-on.git",
-    "version": 25
+    "version": 26
 }

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40", "41", "42"],
+    "shell-version": ["40", "41", "42", "43"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",

--- a/multi-monitors-add-on@spin83/metadata.json
+++ b/multi-monitors-add-on@spin83/metadata.json
@@ -1,10 +1,10 @@
 {
-    "shell-version": ["3.38"],
+    "shell-version": ["40"],
     "uuid": "multi-monitors-add-on@spin83",
     "name": "Multi Monitors Add-On",
     "settings-schema": "org.gnome.shell.extensions.multi-monitors-add-on",
     "gettext-domain": "multi-monitors-add-on",
     "description": "Add multiple monitors overview and panel for gnome-shell.",
     "url": "https://github.com/spin83/multi-monitors-add-on.git",
-    "version": 23
+    "version": 24
 }

--- a/multi-monitors-add-on@spin83/mmoverview.js
+++ b/multi-monitors-add-on@spin83/mmoverview.js
@@ -278,6 +278,84 @@ const MultiMonitorsThumbnailsBox = (() => {
     }, MultiMonitorsThumbnailsBox);
 })();
 
+/* This isn't compatible with GNOME 40 and i don't know how to fix it -- TH
+var MultiMonitorsSlidingControl = (() => {
+    let MultiMonitorsSlidingControl = class MultiMonitorsSlidingControl extends St.Widget {
+    _init(params) {
+        params = Params.parse(params, { slideDirection: OverviewControls.SlideDirection.LEFT });
+
+        this.layout = new OverviewControls.SlideLayout();
+        this.layout.slideDirection = params.slideDirection;
+        super._init({
+            layout_manager: this.layout,
+            style_class: 'overview-controls',
+            clip_to_allocation: true,
+        });
+
+        this._visible = true;
+        this._inDrag = false;
+
+        this.connect('destroy', this._onDestroy.bind(this));
+        this._hidingId = Main.overview.connect('hiding', this._onOverviewHiding.bind(this));
+
+        this._itemDragBeginId = Main.overview.connect('item-drag-begin', this._onDragBegin.bind(this));
+        this._itemDragEndId = Main.overview.connect('item-drag-end', this._onDragEnd.bind(this));
+        this._itemDragCancelledId = Main.overview.connect('item-drag-cancelled', this._onDragEnd.bind(this));
+
+        this._windowDragBeginId = Main.overview.connect('window-drag-begin', this._onWindowDragBegin.bind(this));
+        this._windowDragCancelledId = Main.overview.connect('window-drag-cancelled', this._onWindowDragEnd.bind(this));
+        this._windowDragEndId = Main.overview.connect('window-drag-end', this._onWindowDragEnd.bind(this));
+    }
+
+    _onDestroy() {
+        Main.overview.disconnect(this._hidingId);
+
+        Main.overview.disconnect(this._itemDragBeginId);
+        Main.overview.disconnect(this._itemDragEndId);
+        Main.overview.disconnect(this._itemDragCancelledId);
+
+        Main.overview.disconnect(this._windowDragBeginId);
+        Main.overview.disconnect(this._windowDragCancelledId);
+        Main.overview.disconnect(this._windowDragEndId);
+    }};
+
+    MultiMonitors.copyClass(OverviewControls.SlidingControl, MultiMonitorsSlidingControl);
+    return GObject.registerClass(MultiMonitorsSlidingControl);
+})();
+
+var MultiMonitorsThumbnailsSlider = (() => {
+    let MultiMonitorsThumbnailsSlider = class MultiMonitorsThumbnailsSlider extends MultiMonitorsSlidingControl {
+    _init(thumbnailsBox) {
+        super._init({ slideDirection: OverviewControls.SlideDirection.RIGHT });
+
+        this._thumbnailsBox = thumbnailsBox;
+
+        this.request_mode = Clutter.RequestMode.WIDTH_FOR_HEIGHT;
+        this.reactive = true;
+        this.track_hover = true;
+        this.add_actor(this._thumbnailsBox);
+
+        this._monitorsChangedId = Main.layoutManager.connect('monitors-changed', this._updateSlide.bind(this));
+        this._activeWorkspaceChangedId = global.workspace_manager.connect('active-workspace-changed',
+                                         this._updateSlide.bind(this));
+        this._notifyNWorkspacesId = global.workspace_manager.connect('notify::n-workspaces',
+                                         this._updateSlide.bind(this));
+        this.connect('notify::hover', this._updateSlide.bind(this));
+        this._thumbnailsBox.bind_property('visible', this, 'visible', GObject.BindingFlags.SYNC_CREATE);
+    }
+
+    _onDestroy() {
+        global.workspace_manager.disconnect(this._activeWorkspaceChangedId);
+        global.workspace_manager.disconnect(this._notifyNWorkspacesId);
+        Main.layoutManager.disconnect(this._monitorsChangedId);
+        super._onDestroy();
+    }};
+
+    MultiMonitors.copyClass(OverviewControls.ThumbnailsSlider, MultiMonitorsThumbnailsSlider);
+    return GObject.registerClass(MultiMonitorsThumbnailsSlider);
+})();
+*/
+
 var MultiMonitorsControlsManager = GObject.registerClass(
 class MultiMonitorsControlsManager extends St.Widget {
     _init(index) {

--- a/multi-monitors-add-on@spin83/mmoverview.js
+++ b/multi-monitors-add-on@spin83/mmoverview.js
@@ -365,7 +365,12 @@ class MultiMonitorsControlsManager extends St.Widget {
         this._fixGeometry = 0;
         this._visible = false;
 
-        let layout = new OverviewControls.ControlsManagerLayout();
+        let layout
+        if (OverviewControls.ControlsManagerLayout) {
+            layout = new OverviewControls.ControlsManagerLayout();
+        } else {
+            layout = new OverviewControls.ControlsLayout();
+        }
         super._init({
             layout_manager: layout,
             x_expand: true,

--- a/multi-monitors-add-on@spin83/mmoverview.js
+++ b/multi-monitors-add-on@spin83/mmoverview.js
@@ -365,7 +365,7 @@ class MultiMonitorsControlsManager extends St.Widget {
         this._fixGeometry = 0;
         this._visible = false;
 
-        let layout = new OverviewControls.ControlsLayout();
+        let layout = new OverviewControls.ControlsManagerLayout();
         super._init({
             layout_manager: layout,
             x_expand: true,

--- a/multi-monitors-add-on@spin83/mmpanel.js
+++ b/multi-monitors-add-on@spin83/mmpanel.js
@@ -376,12 +376,6 @@ var MultiMonitorsPanel = (() => {
         this._rightBox = new St.BoxLayout({ name: 'panelRight' });
         this.add_child(this._rightBox);
 
-        this._leftCorner = new Panel.PanelCorner(St.Side.LEFT);
-        this.add_child(this._leftCorner);
-
-        this._rightCorner = new Panel.PanelCorner(St.Side.RIGHT);
-        this.add_child(this._rightCorner);
-
         this._showingId = Main.overview.connect('showing', () => {
             this.add_style_pseudo_class('overview');
         });


### PR DESCRIPTION
This adds partial support for GNOME 40 (see #148). Some more work is needed to restore full functionality, but this at least lets you extend the panel to additional monitors and edit preferences.

Summary of changes:

- Replaced ViewSelector with SearchController
- Commented out code related to MultiMonitorsSlidingControl
- Make prefs.js compatible with GTK4